### PR TITLE
Add additional date formats

### DIFF
--- a/rule.go
+++ b/rule.go
@@ -186,6 +186,24 @@ var RFC3339 CheckFunc = func(r *http.Request, param string, _ Options) error {
 	return DateFormat(r, param, Options{"format": time.RFC3339})
 }
 
+// RFC1123 returns an error if the parameter does not satisfy
+// the RFC1123 format.
+var RFC1123 CheckFunc = func(r *http.Request, param string, _ Options) error {
+	return DateFormat(r, param, Options{"format": time.RFC1123})
+}
+
+// RFC822 returns an error if the parameter does not satisfy the
+// RFC822 format.
+var RFC822 CheckFunc = func(r *http.Request, param string, _ Options) error {
+	return DateFormat(r, param, Options{"format": time.RFC822})
+}
+
+// UnixDate returns an error if the parameter does not satisfy
+// the format defined in Go's UnixDate const.
+var UnixDate CheckFunc = func(r *http.Request, param string, _ Options) error {
+	return DateFormat(r, param, Options{"format": time.UnixDate})
+}
+
 // DateFormat returns an error if the parameter does not
 // satisfy the date format passed in the Options struct.
 var DateFormat CheckFunc = func(r *http.Request, param string, o Options) error {

--- a/rule_test.go
+++ b/rule_test.go
@@ -78,6 +78,24 @@ func TestRules(t *testing.T) {
 			nil,
 		},
 		{
+			RFC1123,
+			[]string{"Tue, 22 Jun 1992 10:00:00 GMT", "Tue, 18 Oct 1993 10:00:00 GMT"},
+			[]string{"1993-10-18", "1992-06-22"},
+			nil,
+		},
+		{
+			RFC822,
+			[]string{"22 Jun 92 10:00 GMT", "18 Oct 93 13:00 GMT"},
+			[]string{"1992-06-22"},
+			nil,
+		},
+		{
+			UnixDate,
+			[]string{"Mon Jan 16 15:04:05 MST 2006", "Tue Jun 22 10:00:00 GMT 1992"},
+			[]string{"1993-10-18", "1990-11-11"},
+			nil,
+		},
+		{
 			DateFormat,
 			[]string{"2016/02/29", "2019/10/18", "1992/06/22"},
 			[]string{"2016-02-29", "2019-10-18", "1992-06-22"},


### PR DESCRIPTION
Adds `RFC1123`, `RFC822`, and `UnixDate` validators.

Closes #2.